### PR TITLE
"rnpm" is deprecated and support for it will be removed in next major version of the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
   },
   "jest": {
     "preset": "react-native"
-  },
-  "rnpm": {
-    "assets": ["./App/Assets/fonts"]
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  dependency: {
+    assets: ['./App/Assets/fonts']
+  }
+};


### PR DESCRIPTION
"rnpm" is deprecated and support for it will be removed in next major version of the CLI.

[link](https://github.com/react-native-community/cli/blob/master/docs/configuration.md)